### PR TITLE
Add a prop to show all 11 certificates

### DIFF
--- a/theme/store/blocks/home/products-slider.jsonc
+++ b/theme/store/blocks/home/products-slider.jsonc
@@ -20,7 +20,10 @@
   // UNIVERSAL
 	"list-context.product-list#home-products-slider": {
 		"blocks": ["product-summary.shelf#home-products-slider"],
-		"children": ["slider-layout#home-products-slider"]
+		"children": ["slider-layout#home-products-slider"],
+		"props": {
+			"maxItems": 15
+		}
 	},
 
 	"product-summary.shelf#home-products-slider": {


### PR DESCRIPTION
Por default o list-context.product-list só mostar 10 itens. Adicionei uma prop de maxItems como 15 para visualizar todos os nosso produtos.